### PR TITLE
Fix Day One Startup & End DMs

### DIFF
--- a/CMPUT-250-Project/Assets/ScriptableObjects/Days/Day One.asset
+++ b/CMPUT-250-Project/Assets/ScriptableObjects/Days/Day One.asset
@@ -30,5 +30,7 @@ MonoBehaviour:
   PoolOrder:
   - PoolIndex: 0
     UserCount: 10
-    Before: []
-    After: []
+    Before:
+    - {fileID: 11400000, guid: 33d83fdd621ae47188ee41fecc01d67c, type: 2}
+    After:
+    - {fileID: 11400000, guid: 3d62789954ce30834b1ab74f60732d69, type: 2}


### PR DESCRIPTION
Literally just adds an event for the before and afters of the single user pool for Day 1